### PR TITLE
Update stacked item API calls to be compatible with both old and new versions of Deadlock's mods

### DIFF
--- a/prototypes/bobsDeadlockStackCrate/angels_addon.lua
+++ b/prototypes/bobsDeadlockStackCrate/angels_addon.lua
@@ -1,5 +1,5 @@
 --stacking
-if mods["DeadlockStacking"] then
+if deadlock_stacking then
 	--Angels & UP ores
 	if data.raw["item"]["angels-ore1"] then 
 		deadlock_stacking.create("angels-ore1", "__morebobs__/graphics/icons/stacking/ores/angel/angels-ore1.png", "deadlock-stacking-1", 32)

--- a/prototypes/bobsDeadlockStackCrate/bobsDeadlockStackCrate.lua
+++ b/prototypes/bobsDeadlockStackCrate/bobsDeadlockStackCrate.lua
@@ -1,5 +1,5 @@
 --stacking
-if mods["DeadlockStacking"] then	
+if deadlock_stacking then	
 	--Circuits Redux
 	if mods["ShinyBobGFX"] then
 		if settings.startup["replace-circuits"] and settings.startup["replace-circuits"].value == true then

--- a/prototypes/bobsDeadlockStackCrate/bobs_addon.lua
+++ b/prototypes/bobsDeadlockStackCrate/bobs_addon.lua
@@ -1,5 +1,5 @@
 --stacking
-if mods["DeadlockStacking"] then
+if deadlock_stacking then
 	--Bobs ores
 	if data.raw["item"]["bauxite-ore"] then 
 		deadlock_stacking.create("bauxite-ore", "__morebobs__/graphics/icons/stacking/ores/bob/bauxite-ore.png", "deadlock-stacking-1", 32)

--- a/prototypes/bobsDeadlockStackCrate/kao_bob.lua
+++ b/prototypes/bobsDeadlockStackCrate/kao_bob.lua
@@ -1,5 +1,5 @@
 --stacking
-if mods["DeadlockStacking"] then
+if deadlock_stacking then
 	--KAO extended
 	if data.raw["item"]["advanced-structure-components"] then
 		deadlock_stacking.create("advanced-structure-components", "__morebobs__/graphics/icons/stacking/kao/stacked-advancedSC.png", "deadlock-stacking-3", 32)

--- a/prototypes/bobsDeadlockStackCrate/other_mods.lua
+++ b/prototypes/bobsDeadlockStackCrate/other_mods.lua
@@ -1,5 +1,5 @@
 --stacking
-if mods["DeadlockStacking"] then
+if deadlock_stacking then
 	--AAI
 	if data.raw["item"]["wooden-gear"] then
 		deadlock_stacking.create("wooden-gear", "__morebobs__/graphics/icons/stacking/gearbearing/wood-gear.png", "deadlock-stacking-1", 32)


### PR DESCRIPTION
Hey,

I'm picking up maintaining Deadlock's mods for 0.17, and part of the work I'm doing is a refactor from two mods into one mod for both loaders and beltboxes.

The new mod provides an identical API to the old one, so no changes are needed to the API calls themselves - but, because the new mod has a new mod name, the current checks for the presence of DSB don't work on the 0.17 version.

This updates these checks to look for the presence of the API instead of the specific mod - but if you prefer, something like `if mods["DeadlockStacking"] or mods["deadlock-beltboxes-loaders"] then` would work instead to load if either mod is present.

Thanks!